### PR TITLE
Move happy path test to integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,6 @@ description = "Encrypted messaging over the Bitcoin P2P Protocol as specified by
 repository = "https://github.com/rustaceanrob/bip324"
 readme = "README.md"
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 secp256k1 = { version="0.28.2" }
 rand = "0.8.4"
@@ -24,5 +21,4 @@ hex = "0.4.3"
 [lib]
 name = "bip324"
 path = "src/lib.rs"
-
 

--- a/tests/round_trips.rs
+++ b/tests/round_trips.rs
@@ -2,7 +2,9 @@ use bip324::{
     initialize_v2_handshake, initiator_complete_v2_handshake, receive_v2_handshake,
     responder_complete_v2_handshake,
 };
-fn main() {
+
+#[test]
+fn hello_world_happy_path() {
     // Alice starts a connection with Bob by making a pub/priv keypair and sending a message to Bob.
     let handshake_init = initialize_v2_handshake(None).unwrap();
     // Bob parses Alice's message, generates his pub/priv key, and sends a message back.


### PR DESCRIPTION
Shifting over the happy path integration test so it is run with `cargo test`. A few auto fmts along the way.