### PR TITLE
Remove session keys from complete handshake struct

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -30,11 +30,9 @@ pub struct ResponderHandshake {
 }
 
 /// The result after completing a handshake.
-#[allow(dead_code)]
 pub struct CompleteHandshake {
     /// The final message to send to the responder.
     pub message: Vec<u8>,
-    pub(crate) session_keys: SessionKeyMaterial,
     /// The struct used to encode and decode subsequent packets.
     pub packet_handler: PacketHandler,
 }


### PR DESCRIPTION
Remove dead key session_keys from the complete handshake struct response. Updated one test, but dropped the rest since the plan is to split off the chacha stuff anyways, let me know if that is a bad idea though.

Wondering if it's worth breaking the mutable packet handler out of the handshake structs, I'll dig into that a bit.