### PR TITLE
BIP324 HKDF implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,22 +16,28 @@ dependencies = [
 name = "bip324"
 version = "0.1.0"
 dependencies = [
+ "bitcoin_hashes",
  "chacha20",
  "chacha20poly1305",
  "hex",
- "hkdf",
  "rand",
  "secp256k1",
- "sha2",
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
+name = "bitcoin-internals"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "generic-array",
+ "bitcoin-internals",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -102,17 +108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,22 +135,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
+name = "hex-conservative"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "inout"
@@ -241,17 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ rust-version = "1.56.1"
 [dependencies]
 secp256k1 = { version="0.28.2" }
 rand = "0.8.4"
-hkdf = "0.12.4"
-sha2 = "0.10.8"
+bitcoin_hashes = "0.13.0"
 chacha20poly1305 = "0.10.1"
 chacha20 = "0.9.1"
 

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -52,10 +52,10 @@ impl Hkdf {
 
         // Counter starts at "1" based on RFC5869 spec and is committed to in the hash.
         let mut counter = 1u8;
-        // Ceiling calculation for the total number of hashes required for the expand.
-        let total_hashes = (okm.len() + HASH_LENGTH_BYTES - 1) / HASH_LENGTH_BYTES;
+        // Ceiling calculation for the total number of blocks (iterations) required for the expand.
+        let total_blocks = (okm.len() + HASH_LENGTH_BYTES - 1) / HASH_LENGTH_BYTES;
 
-        while counter <= total_hashes as u8 {
+        while counter <= total_blocks as u8 {
             let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(&self.prk);
 
             // First block does not have a previous block,
@@ -71,7 +71,7 @@ impl Hkdf {
             let t = Hmac::from_engine(hmac_engine);
             let start_index = (counter as usize - 1) * HASH_LENGTH_BYTES;
             // Last block might not take full hash length.
-            let end_index = if counter == (total_hashes as u8) {
+            let end_index = if counter == (total_blocks as u8) {
                 okm.len()
             } else {
                 counter as usize * HASH_LENGTH_BYTES

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -1,0 +1,37 @@
+use bitcoin_hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
+use core::fmt;
+
+/// Structure for InvalidLength, used for output error handling.
+#[derive(Copy, Clone, Debug)]
+pub struct InvalidLength;
+
+impl fmt::Display for InvalidLength {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid number of blocks, too large output")
+    }
+}
+
+// Hardcoding to SHA256 hash and hmac implemenation.
+pub struct Hkdf {
+    prk: Hmac<sha256::Hash>,
+}
+
+impl Hkdf {
+    // TODO: make salt optional.
+    pub fn new(salt: &[u8], ikm: &[u8]) -> Self {
+        let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(salt);
+        hmac_engine.input(ikm);
+        Hkdf {
+            prk: Hmac::from_engine(hmac_engine),
+        }
+    }
+    pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), InvalidLength> {
+        // TODO: actually loop and do not assume exact 32 byte match.
+        let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(&self.prk.to_byte_array());
+        hmac_engine.input(info);
+        hmac_engine.input(&[1u8]);
+        let t = Hmac::from_engine(hmac_engine);
+        okm.copy_from_slice(&t.to_byte_array());
+        return Ok(());
+    }
+}

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -50,6 +50,7 @@ impl Hkdf {
             return Err(InvalidLength);
         }
 
+        // Counter starts at "1" based on RFC5869 spec and is committed to in the hash.
         let mut counter = 1u8;
         // Ceiling calculation for the total number of hashes required for the expand.
         let total_hashes = (okm.len() + HASH_LENGTH_BYTES - 1) / HASH_LENGTH_BYTES;
@@ -106,6 +107,28 @@ mod tests {
         assert_eq!(
             hex::encode(okm),
             "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+        );
+    }
+
+    #[test]
+    fn test_longer_inputs_outputs() {
+        let salt = hex::decode(
+            "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+        ).unwrap();
+        let ikm = hex::decode(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f"
+        ).unwrap();
+        let info = hex::decode(
+            "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        ).unwrap();
+
+        let hkdf = Hkdf::extract(&salt, &ikm);
+        let mut okm = [0u8; 82];
+        hkdf.expand(&info, &mut okm).unwrap();
+
+        assert_eq!(
+            hex::encode(okm),
+            "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
         );
     }
 }

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -1,7 +1,17 @@
+//! HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
+//!
+//! The interface is limited to the BIP324 use case for now. This
+//! includes hardcoding to the SHA256 hash implementation, as well
+//! as requiring an extract step.
+
 use bitcoin_hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
 use core::fmt;
 
-/// Structure for InvalidLength, used for output error handling.
+// Hardcoded hash length for SHA256 backed implementatoin.
+const HASH_LENGTH_BYTES: usize = sha256::Hash::LEN;
+// Output keying material max length multiple.
+const MAX_OUTPUT_BYTES: usize = 255;
+
 #[derive(Copy, Clone, Debug)]
 pub struct InvalidLength;
 
@@ -11,27 +21,66 @@ impl fmt::Display for InvalidLength {
     }
 }
 
-// Hardcoding to SHA256 hash and hmac implemenation.
+impl std::error::Error for InvalidLength {}
+
+/// HMAC-based Extract-and-Expand Key Derivation Function (HKDF).
 pub struct Hkdf {
-    prk: Hmac<sha256::Hash>,
+    /// Pseudorandom key based on the extract step.
+    prk: [u8; HASH_LENGTH_BYTES],
 }
 
 impl Hkdf {
-    // TODO: make salt optional.
-    pub fn new(salt: &[u8], ikm: &[u8]) -> Self {
+    /// Initialize a HKDF by performing the extract step.
+    pub fn extract(salt: &[u8], ikm: &[u8]) -> Self {
+        // Hardcoding SHA256 for now, might be worth parameterizing hash function.
         let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(salt);
         hmac_engine.input(ikm);
-        Hkdf {
-            prk: Hmac::from_engine(hmac_engine),
+        Self {
+            prk: Hmac::from_engine(hmac_engine)
+                .to_byte_array()
+                .try_into()
+                .expect("32 bytes hash"),
         }
     }
+
+    /// Expand the key to generate an output.
     pub fn expand(&self, info: &[u8], okm: &mut [u8]) -> Result<(), InvalidLength> {
-        // TODO: actually loop and do not assume exact 32 byte match.
-        let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(&self.prk.to_byte_array());
-        hmac_engine.input(info);
-        hmac_engine.input(&[1u8]);
-        let t = Hmac::from_engine(hmac_engine);
-        okm.copy_from_slice(&t.to_byte_array());
-        return Ok(());
+        // Length of output keying material must be less than 255 * hash length.
+        if okm.len() > (MAX_OUTPUT_BYTES * HASH_LENGTH_BYTES) {
+            return Err(InvalidLength);
+        }
+
+        let mut counter = 1u8;
+        // Ceiling calculation for the total number of hashes required for the expand.
+        let total_hashes = (okm.len() + HASH_LENGTH_BYTES - 1) / HASH_LENGTH_BYTES;
+
+        while counter <= total_hashes as u8 {
+            let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(&self.prk);
+
+            // Handle special case for first hash where t is 0 byte,
+            // otherwise include last hash in the HMAC input.
+            if counter != 1u8 {
+                let previous_start_index = (counter as usize - 2) * HASH_LENGTH_BYTES;
+                let previous_end_index = (counter as usize - 1) * HASH_LENGTH_BYTES;
+                hmac_engine.input(&okm[previous_start_index..previous_end_index]);
+            }
+            hmac_engine.input(info);
+            hmac_engine.input(&[counter]);
+
+            let t = Hmac::from_engine(hmac_engine);
+            let start_index = (counter as usize - 1) * HASH_LENGTH_BYTES;
+            // Handle special case of last hash not taking full hash length.
+            let end_index = if counter == (total_hashes as u8) {
+                okm.len()
+            } else {
+                counter as usize * HASH_LENGTH_BYTES
+            };
+
+            okm[start_index..end_index].copy_from_slice(&t.to_byte_array());
+
+            counter = counter + 1;
+        }
+
+        Ok(())
     }
 }

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -39,7 +39,7 @@ impl Hkdf {
             prk: Hmac::from_engine(hmac_engine)
                 .to_byte_array()
                 .try_into()
-                .expect("32 bytes hash"),
+                .expect("32 byte hash"),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ fn initialize_session_key_material(ikm: &[u8]) -> SessionKeyMaterial {
     let ikm_salt = "bitcoin_v2_shared_secret".as_bytes();
     let magic = NETWORK_MAGIC.as_slice();
     let salt = [ikm_salt, magic].concat();
-    let hk = Hkdf::new(salt.as_slice(), ikm);
+    let hk = Hkdf::extract(salt.as_slice(), ikm);
     let mut session_id = [0u8; 32];
     let session_info = "session_id".as_bytes();
     hk.expand(session_info, &mut session_id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@
 //! ```
 
 mod error;
+mod hkdf;
 mod types;
+
 use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
 use chacha20::ChaCha20;
 use chacha20poly1305::{AeadInPlace, ChaCha20Poly1305, KeyInit, Nonce};
@@ -49,7 +51,6 @@ use secp256k1::{
     ellswift::{ElligatorSwift, ElligatorSwiftParty},
     PublicKey, Secp256k1, SecretKey,
 };
-use sha2::Sha256;
 pub use types::SessionKeyMaterial;
 pub use types::{
     CompleteHandshake, EcdhPoint, HandshakeRole, InitiatorHandshake, ReceivedMessage,
@@ -373,7 +374,7 @@ fn initialize_session_key_material(ikm: &[u8]) -> SessionKeyMaterial {
     let ikm_salt = "bitcoin_v2_shared_secret".as_bytes();
     let magic = NETWORK_MAGIC.as_slice();
     let salt = [ikm_salt, magic].concat();
-    let (_, hk) = Hkdf::<Sha256>::extract(Some(salt.as_slice()), ikm);
+    let hk = Hkdf::new(salt.as_slice(), ikm);
     let mut session_id = [0u8; 32];
     let session_info = "session_id".as_bytes();
     hk.expand(session_info, &mut session_id)


### PR DESCRIPTION
Dropping the `sha2` and `hkdf` dependencies in favor of an internal implementation for HKDF based on RFC5869 and `bitcoin_hashes`. This is limited to BIP324 requirements, so hardcoded with SHA256. The interface is also not as flexible as RFC5869 allows.