### PR TITLE
No standard library (no_std) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           rustup default ${{ matrix.toolchain }}
           rustup component add --toolchain ${{ matrix.toolchain }} rustfmt
           rustup component add --toolchain ${{ matrix.toolchain }} clippy
-          rustup target add --toolchain ${{ matrix.toolchain }} thumbv7m-none-eabi
+          
           rustup update ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --verbose
@@ -33,6 +33,8 @@ jobs:
       - name: Test
         run: cargo test --verbose
       - name: Check No Standard Library Support
-        run: cargo build --target thumbv7m-none-eabi --no-default-features
-
+        run: |
+          rustup target add --toolchain ${{ matrix.toolchain }} thumbv7m-none-eabi
+          cargo install cross
+          cross build --target thumbv7m-none-eabi --no-default-features
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           rustup default ${{ matrix.toolchain }}
           rustup component add --toolchain ${{ matrix.toolchain }} rustfmt
           rustup component add --toolchain ${{ matrix.toolchain }} clippy
-          
           rustup update ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Cargo Build & Test
+name: Build & Test
 
 on:
   push:
@@ -7,8 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: Rust - latest
+  build-and-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,5 +27,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Test
         run: cargo test --verbose
+      - name: Check No Standard Library Support
+        run: cargo build --target thumbv7m-none-eabi --no-default-features
 
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Update Toolchain
-        run: rustup default ${{ matrix.toolchain }} && rustup component add --toolchain ${{ matrix.toolchain }} rustfmt && rustup component add --toolchain ${{ matrix.toolchain }} clippy && rustup update ${{ matrix.toolchain }} 
+        run: |
+          rustup default ${{ matrix.toolchain }}
+          rustup component add --toolchain ${{ matrix.toolchain }} rustfmt
+          rustup component add --toolchain ${{ matrix.toolchain }} clippy
+          rustup target add --toolchain ${{ matrix.toolchain }} thumbv7m-none-eabi
+          rustup update ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --verbose
       - name: Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,12 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bip324"
 version = "0.1.0"
 dependencies = [
@@ -26,7 +20,6 @@ dependencies = [
  "chacha20",
  "chacha20poly1305",
  "hex",
- "num-bigint",
  "rand",
  "secp256k1",
 ]
@@ -161,35 +154,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "num-bigint"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bip324"
 version = "0.1.0"
 dependencies = [
@@ -20,6 +26,7 @@ dependencies = [
  "chacha20",
  "chacha20poly1305",
  "hex",
+ "num-bigint",
  "rand",
  "secp256k1",
 ]
@@ -154,6 +161,35 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ std = ["rand/std", "rand/std_rng"]
 [dependencies]
 secp256k1 = { version="0.28.2" }
 rand = { version = "0.8.4", default-features = false }
-bitcoin_hashes = "0.13.0"
+bitcoin_hashes = { version = "0.13.0", default-features = false }
+num-bigint = "0.4.4"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ rust-version = "1.56.1"
 
 [features]
 default = ["std"]
-std = []
+std = ["rand/std", "rand/std_rng"]
 
 [dependencies]
 secp256k1 = { version="0.28.2" }
-rand = "0.8.4"
+rand = { version = "0.8.4", default-features = false }
 bitcoin_hashes = "0.13.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/rustaceanrob/bip324"
 readme = "README.md"
 rust-version = "1.56.1"
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 secp256k1 = { version="0.28.2" }
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ rust-version = "1.56.1"
 
 [features]
 default = ["std"]
-std = ["rand/std", "rand/std_rng"]
+std = ["secp256k1/std", "rand/std", "rand/std_rng"]
 
 [dependencies]
-secp256k1 = { version="0.28.2" }
+secp256k1 = { version="0.28.2", default-features = false}
 rand = { version = "0.8.4", default-features = false }
 bitcoin_hashes = { version = "0.13.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ std = ["rand/std", "rand/std_rng"]
 secp256k1 = { version="0.28.2" }
 rand = { version = "0.8.4", default-features = false }
 bitcoin_hashes = { version = "0.13.0", default-features = false }
-num-bigint = "0.4.4"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/chachapoly.rs
+++ b/src/chachapoly.rs
@@ -4,6 +4,8 @@ use crate::poly1305::Poly1305;
 pub use error::ChaCha20Poly1305DecryptionError;
 use error::ChaCha20Poly1305EncryptionError;
 
+use alloc::string::ToString;
+
 #[derive(Debug)]
 pub struct ChaCha20Poly1305 {
     key: [u8; 32],

--- a/src/chachapoly.rs
+++ b/src/chachapoly.rs
@@ -1,9 +1,8 @@
 use crate::chacha::ChaCha20;
 use crate::error;
 use crate::poly1305::Poly1305;
-use error::ChaCha20Poly1305EncryptionError;
-extern crate alloc;
 pub use error::ChaCha20Poly1305DecryptionError;
+use error::ChaCha20Poly1305EncryptionError;
 
 #[derive(Debug)]
 pub struct ChaCha20Poly1305 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
-use std::error::Error;
-extern crate alloc;
 use core::fmt;
-// use alloc::string::String;
+
+use alloc::string::String;
 
 /// An error occured responding to an inbound handshake.
 #[derive(Debug)]
@@ -12,8 +11,8 @@ pub enum ResponderHandshakeError {
     EncryptionError(String),
 }
 
-impl std::fmt::Display for ResponderHandshakeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ResponderHandshakeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ResponderHandshakeError::ECC(e) => write!(f, "ECC error: {}", e),
             ResponderHandshakeError::IncorrectMessage(s) => write!(f, "Version error: {}", s),
@@ -22,8 +21,9 @@ impl std::fmt::Display for ResponderHandshakeError {
     }
 }
 
-impl Error for ResponderHandshakeError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+#[cfg(feature = "std")]
+impl std::error::Error for ResponderHandshakeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ResponderHandshakeError::ECC(e) => Some(e),
             ResponderHandshakeError::IncorrectMessage(_) => None,
@@ -41,8 +41,8 @@ pub enum HandshakeCompletionError {
     DecryptionError(String),
 }
 
-impl std::fmt::Display for HandshakeCompletionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for HandshakeCompletionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HandshakeCompletionError::MessageTooShort(s) => write!(f, "Handshake error: {}", s),
             HandshakeCompletionError::TooMuchGarbage(s) => write!(f, "Handshake error: {}", s),
@@ -52,8 +52,9 @@ impl std::fmt::Display for HandshakeCompletionError {
     }
 }
 
-impl Error for HandshakeCompletionError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+#[cfg(feature = "std")]
+impl std::error::Error for HandshakeCompletionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             HandshakeCompletionError::MessageTooShort(_s) => None,
             HandshakeCompletionError::TooMuchGarbage(_s) => None,
@@ -71,8 +72,8 @@ pub enum FSChaChaError {
     Poly1305Decryption(String),
 }
 
-impl std::fmt::Display for FSChaChaError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for FSChaChaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FSChaChaError::StreamEncryption(s) => write!(f, "Cipher error: {}", s),
             FSChaChaError::StreamDecryption(s) => write!(f, "Cipher error: {}", s),
@@ -82,8 +83,9 @@ impl std::fmt::Display for FSChaChaError {
     }
 }
 
-impl Error for FSChaChaError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+#[cfg(feature = "std")]
+impl std::error::Error for FSChaChaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             FSChaChaError::StreamEncryption(_s) => None,
             FSChaChaError::StreamDecryption(_s) => None,

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -21,6 +21,7 @@ impl fmt::Display for InvalidLength {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for InvalidLength {}
 
 /// HMAC-based Extract-and-Expand Key Derivation Function (HKDF).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,10 @@
 //! assert_eq!(message, secret_message);
 //! ```
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
+extern crate alloc;
+
 mod chacha;
 mod chachapoly;
 mod error;
@@ -45,6 +49,12 @@ mod types;
 
 use chacha::ChaCha20;
 use chachapoly::ChaCha20Poly1305;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use alloc::string::ToString;
+
 use error::FSChaChaError;
 pub use error::{HandshakeCompletionError, ResponderHandshakeError};
 use hkdf::Hkdf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ use hkdf::Hkdf;
 use rand::Rng;
 use secp256k1::{
     ellswift::{ElligatorSwift, ElligatorSwiftParty},
+    ffi::types::AlignedType,
     PublicKey, Secp256k1, SecretKey,
 };
 pub use types::SessionKeyMaterial;
@@ -379,7 +380,8 @@ fn gen_key() -> Result<SecretKey, secp256k1::Error> {
 }
 
 fn new_elligator_swift(sk: SecretKey) -> ElligatorSwift {
-    let curve = Secp256k1::new();
+    let mut buf_ful = vec![AlignedType::zeroed(); Secp256k1::preallocate_size()];
+    let curve = Secp256k1::preallocated_new(&mut buf_ful).unwrap();
     let pk = PublicKey::from_secret_key(&curve, &sk);
     ElligatorSwift::from_pubkey(pk)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use crate::PacketHandler;
+use alloc::vec::Vec;
 use secp256k1::{ellswift::ElligatorSwift, SecretKey};
 
 /// A point on the curve used to complete the handshake.


### PR DESCRIPTION
Created a crate feature flag which gates all implementation details which require the standard library. This feature flag is on by default, but follows the standard pattern where it can be disabled with the `default-features` flag. BIP324's own deps have been cleaned up to only pull in std deps when necessary.

Added a new CI check to make sure the library is actually `no_std` compliant. Introduced the `cross` dependency to do this since it was a little flaky locally, hopefully not too much trouble in CI.

The Random Number Generator std dep required some minor interface tweaks where the RNG is passed down implicitly if called from a function that is only built for std.

All allocation dependencies are now explicit, but would need another rev to add another feature flag, e.g. `alloc`, and gate that functionality as well. I think we would have to tweak some interfaces so kicked that can for the time being.