### PR TITLE
Add MSRV build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Minumum Supported Rust Version (MSRV) is 1.56.1 but
-        # having some weird issues with the memchr dependency.
-        toolchain: [stable, beta, nightly]
+        # Minumum Supported Rust Version (MSRV) is 1.56.1.
+        toolchain: [1.56.1, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - name: Update Toolchain
@@ -74,8 +73,10 @@ jobs:
           cargo test --package bip324 --verbose --no-default-features
           cargo test --package bip324 --verbose --no-default-features --features alloc
       - name: Check No Standard Library Support
+        # The cross tool used to test in a no standard library environment doesn't play nice with our MSRV, so limiting to just stable toolchain.
+        if: matrix.toolchain == 'stable'
         run: |
           rustup target add --toolchain ${{ matrix.toolchain }} thumbv7m-none-eabi
-          cargo install cross
+          cargo install cross --locked
           cross build --package bip324 --target thumbv7m-none-eabi --no-default-features --features alloc
         

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -31,9 +31,9 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "88fb5a785d6b44fd9d6700935608639af1b8356de1e55d5f7c2740f4faa15d82"
 dependencies = [
  "addr2line",
  "cc",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "hermit-abi"
@@ -200,17 +200,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
+ "autocfg",
 ]
 
 [[package]]
@@ -236,12 +237,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
-]
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "parking_lot"

--- a/protocol/src/chacha20poly1305/chacha20.rs
+++ b/protocol/src/chacha20poly1305/chacha20.rs
@@ -359,11 +359,10 @@ mod tests {
         let count = 1;
         let mut chacha = ChaCha20::new(key, nonce, count);
         let mut binding = [8; 3];
-        let to = binding.as_mut_slice();
-        chacha.apply_keystream(to).unwrap();
+        chacha.apply_keystream(&mut binding[..]).unwrap();
         let mut chacha = ChaCha20::new(key, nonce, count);
-        chacha.apply_keystream(to).unwrap();
-        assert_eq!([8; 3], to);
+        chacha.apply_keystream(&mut binding[..]).unwrap();
+        assert_eq!([8; 3], binding);
     }
 
     #[test]
@@ -376,11 +375,10 @@ mod tests {
         let count = 1;
         let mut chacha = ChaCha20::new(key, nonce, count);
         let mut binding = [8; 64];
-        let to = binding.as_mut_slice();
-        chacha.apply_keystream(to).unwrap();
+        chacha.apply_keystream(&mut binding[..]).unwrap();
         let mut chacha = ChaCha20::new(key, nonce, count);
-        chacha.apply_keystream(to).unwrap();
-        assert_eq!([8; 64], to);
+        chacha.apply_keystream(&mut binding[..]).unwrap();
+        assert_eq!([8; 64], binding);
     }
 
     #[test]
@@ -393,13 +391,11 @@ mod tests {
         let count = 64;
         let mut chacha = ChaCha20::new(key, nonce, count);
         let mut binding = *b"Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.";
-        let to = binding.as_mut_slice();
-        chacha.apply_keystream(to).unwrap();
-        assert_eq!(to, Vec::from_hex("6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d807ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42874d").unwrap());
+        chacha.apply_keystream(&mut binding[..]).unwrap();
+        assert_eq!(binding[..], Vec::from_hex("6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d807ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42874d").unwrap());
         let mut chacha = ChaCha20::new(key, nonce, count);
-        chacha.apply_keystream(to).unwrap();
-        let binding = *b"Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.";
-        assert_eq!(binding, to);
+        chacha.apply_keystream(&mut binding[..]).unwrap();
+        assert_eq!(binding, *b"Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.");
     }
 
     #[test]
@@ -412,13 +408,11 @@ mod tests {
         let block: u32 = 1;
         let mut chacha = ChaCha20::new_from_block(key, nonce, block);
         let mut binding = *b"Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.";
-        let to = binding.as_mut_slice();
-        chacha.apply_keystream(to).unwrap();
-        assert_eq!(to, Vec::from_hex("6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d807ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42874d").unwrap());
+        chacha.apply_keystream(&mut binding[..]).unwrap();
+        assert_eq!(binding[..], Vec::from_hex("6e2e359a2568f98041ba0728dd0d6981e97e7aec1d4360c20a27afccfd9fae0bf91b65c5524733ab8f593dabcd62b3571639d624e65152ab8f530c359f0861d807ca0dbf500d6a6156a38e088a22b65e52bc514d16ccf806818ce91ab77937365af90bbf74a35be6b40b8eedf2785e42874d").unwrap());
         chacha.block(block);
-        chacha.apply_keystream(to).unwrap();
-        let binding = *b"Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.";
-        assert_eq!(binding, to);
+        chacha.apply_keystream(&mut binding[..]).unwrap();
+        assert_eq!(binding, *b"Ladies and Gentlemen of the class of '99: If I could offer you only one tip for the future, sunscreen would be it.");
     }
 
     #[cfg(feature = "std")]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -163,7 +163,7 @@ pub struct PacketReader {
 }
 
 impl PacketReader {
-    /// Decode the length, in bytes, of the of the rest imbound message.
+    /// Decode the length, in bytes, of the rest of the inbound message.
     ///
     /// Intended for use with `TcpStream` and `read_exact`. Note that this does not decode to the
     /// length of contents described in BIP324, and is meant to represent the entire imbound message


### PR DESCRIPTION
Locked the two dependencies which were causing issues building on MSRV of 1.56.1:

```
$ cargo update -p memchr --precise 2.4.1 
$ cargo update -p backtrace --precise 0.3.58
```

This is currently only enforced with the lockfile, not sure how fragile that is.

Closes #49 